### PR TITLE
Fix ngFor snippet template variable

### DIFF
--- a/snippets/html.cson
+++ b/snippets/html.cson
@@ -11,7 +11,7 @@
     'description': 'Angular 2 *ngFor snippet'
     'descriptionMoreURL': 'https://angular.io/docs/ts/latest/api/common/NgFor-directive.html'
     'body': """
-    *ngFor="let {1:$item} of ${2:list}"
+    *ngFor="let ${1:item} of ${2:list}"
     """
   'ngIf':
     'prefix': 'ng2-ngIf'


### PR DESCRIPTION
This patch fixes the template for ng2 ngFor snippet, where the '$' sign was at the wrong position in the string.
